### PR TITLE
Fix compilation errors / warnings with GCC 7.3.0

### DIFF
--- a/URLParser.hpp
+++ b/URLParser.hpp
@@ -11,6 +11,10 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if __cplusplus > 199711L
+#define register // Deprecated in C++11
+#endif
+
 namespace http {
     struct url {
         std::string protocol, user, password, host, path, search;
@@ -89,7 +93,6 @@ namespace http {
     {
         char const *in_str = str_source.c_str();
         int in_str_len = strlen(in_str);
-        int out_str_len = 0;
         std::string out_str;
         register unsigned char c;
         unsigned char *to, *start;
@@ -121,7 +124,6 @@ namespace http {
         }
         *to = 0;
         
-        out_str_len = to - start;
         out_str = (char *)start;
         free(start);
         return out_str;
@@ -149,7 +151,6 @@ namespace http {
     {
         char const *in_str = str_source.c_str();
         int in_str_len = strlen(in_str);
-        int out_str_len = 0;
         std::string out_str;
         char *str;
         
@@ -175,7 +176,6 @@ namespace http {
             dest++;
         }
         *dest = '\0';
-        out_str_len = dest - str;
         out_str = str;
         free(str);
         return out_str;

--- a/URLParser.hpp
+++ b/URLParser.hpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <string>
+#include <string.h>
 #include <stdlib.h>
 
 namespace http {

--- a/URLParser.hpp
+++ b/URLParser.hpp
@@ -11,10 +11,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if __cplusplus > 199711L
-#define register // Deprecated in C++11
-#endif
-
 namespace http {
     struct url {
         std::string protocol, user, password, host, path, search;
@@ -94,7 +90,11 @@ namespace http {
         char const *in_str = str_source.c_str();
         int in_str_len = strlen(in_str);
         std::string out_str;
+#if __cplusplus > 199711L
+        unsigned char c;
+#else
         register unsigned char c;
+#endif
         unsigned char *to, *start;
         unsigned char const *from, *end;
         unsigned char hexchars[] = "0123456789ABCDEF";


### PR DESCRIPTION
`strlen` and `strdup` need `#include <string.h>`.
```In file included from example.cpp:2:0:
URLParser.hpp: In function ‘std::__cxx11::string http::URLEncode(const string&)’:
URLParser.hpp:90:26: error: ‘strlen’ was not declared in this scope
         int in_str_len = strlen(in_str);
                          ^~~~~~
URLParser.hpp:90:26: note: suggested alternative: ‘mbrlen’
         int in_str_len = strlen(in_str);
                          ^~~~~~
URLParser.hpp: In function ‘std::__cxx11::string http::URLDecode(const string&)’:
URLParser.hpp:150:26: error: ‘strlen’ was not declared in this scope
         int in_str_len = strlen(in_str);
                          ^~~~~~
URLParser.hpp:150:26: note: suggested alternative: ‘mbrlen’
         int in_str_len = strlen(in_str);
                          ^~~~~~
URLParser.hpp:155:15: error: ‘strdup’ was not declared in this scope
         str = strdup(in_str);
               ^~~~~~
URLParser.hpp:155:15: note: suggested alternative: ‘str’
         str = strdup(in_str);
               ^~~~~~
```

Also fixed compilation warnings below.
```
In file included from example.cpp:2:0:
URLParser.hpp: In function ‘std::__cxx11::string http::URLEncode(const string&)’:
URLParser.hpp:92:13: warning: variable ‘out_str_len’ set but not used [-Wunused-but-set-variable]
         int out_str_len = 0;
             ^~~~~~~~~~~
URLParser.hpp:93:32: warning: ISO C++1z does not allow ‘register’ storage class specifier [-Wregister]
         register unsigned char c;
                                ^
URLParser.hpp: In function ‘std::__cxx11::string http::URLDecode(const string&)’:
URLParser.hpp:152:13: warning: variable ‘out_str_len’ set but not used [-Wunused-but-set-variable]
         int out_str_len = 0;
             ^~~~~~~~~~~
```